### PR TITLE
Breaking change: Change the function name so that IDEs can properly suggest it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# @main
+# @python_main
 
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/python-main)](https://pypi.org/project/python-main/)
 [![PyPI - Version](https://img.shields.io/pypi/v/python-main)](https://pypi.org/project/python-main/)
 
 
-`@main` decorator which runs the tagged function if the current module is being executed as a script.
+`@python_main` is a decorator which:
+- Automatically calls the function(s) tagged with it, if the current module is being **executed as a script**.
+- Does nothing if the current module is being **imported**.
 
-No more `if __name__ == "__main__":` all over the place.
+It is, essentially, similar to the `if __name__ == "__main__":` block, but as a decorator.
 
-That's it!
+That's all it does.
 
 ### Installation
 
@@ -20,14 +22,40 @@ poetry add python-main # ...
 ### Usage
 
 ```python
-from python_main import main
+from python_main import python_main
 
 A = 10
 B = 20
 
 
-@main
+@python_main
 def do_print():
     """This will run if this module is executed."""
     print(A + B)
+```
+
+You can also tag multiple functions with `@python_main` and they will all run if the module is executed, in the order they are defined.
+
+```python
+from python_main import python_main
+
+A = 10
+B = 20
+C = 0
+
+@python_main
+def add_a_to_c():
+    global C
+    C += A
+
+# ... other functions/ definitions ...
+
+@python_main
+def add_b_to_c():
+    global C
+    C += B
+
+# At this point:
+# - C will be 30 if this module is executed as a script.
+# - C will be untouched if this module is imported.
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ from python_main import python_main
 A = 10
 B = 20
 
-
 @python_main
 def do_print():
     """This will run if this module is executed."""

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Automatically calls the function(s) tagged with it, if the current module is being **executed as a script**.
 - Does nothing if the current module is being **imported**.
 
-It is, essentially, similar to the `if __name__ == "__main__":` block, but as a decorator.
+It is, essentially, equivalent to the `if __name__ == "__main__":` construct, but as a decorator.
 
 That's all it does.
 

--- a/python_main/__init__.py
+++ b/python_main/__init__.py
@@ -6,11 +6,16 @@ __CALLABLE_MODULE_PROP = "__module__"
 __MAIN_RETURN_TYPE = TypeVar("__MAIN_RETURN_TYPE")
 
 
-def main(f: Callable[[], __MAIN_RETURN_TYPE]) -> Callable[[], __MAIN_RETURN_TYPE]:
-    if getattr(f, __CALLABLE_MODULE_PROP) == __RAN_AS_SCRIPT_MODULE:
-        f()
-    return f
+def python_main(
+    main_function_to_be_called: Callable[[], __MAIN_RETURN_TYPE]
+) -> Callable[[], __MAIN_RETURN_TYPE]:
+    if (
+        getattr(main_function_to_be_called, __CALLABLE_MODULE_PROP)
+        == __RAN_AS_SCRIPT_MODULE
+    ):
+        main_function_to_be_called()
+    return main_function_to_be_called
 
 
 # Only export the main function
-__all__ = ["main"]
+__all__ = ["python_main"]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,7 +2,7 @@ import builtins
 
 import pytest
 
-from python_main import main
+from python_main import python_main
 
 EXIT_CODE_RECEIVED = -1
 
@@ -44,7 +44,7 @@ def test_assert_function_actually_gets_called(mock_exit):
     __my_main_func.__module__ = "__main__"
 
     # Decorate it
-    main(__my_main_func)
+    python_main(__my_main_func)
 
     # Ensure that our main function was able to call mock_exit with the expected value.
     global EXIT_CODE_RECEIVED
@@ -60,7 +60,7 @@ def test_assert_function_does_not_get_called(mock_exit):
     """
 
     # Call the function, which is coming from a pytest execution and being imported as a module
-    function_returned = main(__my_main_func)
+    function_returned = python_main(__my_main_func)
 
     # Exit code will not have been set.
     global EXIT_CODE_RECEIVED


### PR DESCRIPTION
In my usage, I've found that some IDEs/LSPs actively avoid suggesting an import named like `main()`, as that is a common name used as ... main functions in user code :sweat_smile: 

This PR basically renames `@main` to `@python_main`, avoiding that issue.